### PR TITLE
Fix knowledge base output to use .md extension instead of .xml

### DIFF
--- a/kb_for_prompt/organisms/menu_system.py
+++ b/kb_for_prompt/organisms/menu_system.py
@@ -806,7 +806,7 @@ class MenuSystem:
         # Display the section header
         display_section_header("Knowledge Base Generation", console=self.console)
         # Print explanatory text
-        self.console.print("\nOptionally, generate a Knowledge Base (KB) in XML format")
+        self.console.print("\nOptionally, generate a Knowledge Base (KB) in Markdown format") # Updated format
         self.console.print("from the Markdown files using an LLM.")
         self.console.print("This can be useful for further processing or RAG systems.")
 
@@ -920,8 +920,8 @@ class MenuSystem:
             # User confirmed save - determine target path
             try:
                 output_dir = Path(output_dir_str)
-                # Assuming KB is saved as XML based on prompt description
-                target_path = output_dir / "knowledge_base.xml"
+                # Save KB as Markdown
+                target_path = output_dir / "knowledge_base.md" # CHANGED EXTENSION
 
                 self.console.print(f"Preparing to save KB to: {target_path}")
 

--- a/kb_for_prompt/templates/kb_extraction_prompt.md
+++ b/kb_for_prompt/templates/kb_extraction_prompt.md
@@ -6,7 +6,7 @@ Given the documents below, perform the following tasks:
 4. Include clear headings, subheadings, and proper Markdown formatting.
 5. Ensure all technical details, code examples, and important concepts are preserved.
 6. Create a table of contents at the beginning of the document.
-7. Include the original document path as an inline citation when referencing specific content.
+7. **IMPORTANT**: Do NOT include the original document file paths anywhere in the generated knowledge base. Focus solely on the content.
 
 ## Documents
 {{documents}}

--- a/kb_for_prompt/tests/test_llm_generator.py
+++ b/kb_for_prompt/tests/test_llm_generator.py
@@ -240,7 +240,16 @@ def test_generate_kb_success(mock_scan, mock_load_template, generator, mock_llm_
     call_args, call_kwargs = mock_llm_client.invoke.call_args
     prompt_arg = call_args[0]
     assert isinstance(prompt_arg, str)
-    expected_final_prompt = sample_data["kb_template_content"].replace("{{documents}}", sample_data["xml_data"])
+    
+    # Create XML without path attributes for comparison
+    # We're doing this because our new implementation removes path attributes
+    root = ET.fromstring(sample_data["xml_data"])
+    for doc in root.findall("document"):
+        if 'path' in doc.attrib:
+            del doc.attrib['path']
+    xml_without_paths = ET.tostring(root, encoding="unicode", xml_declaration=False, short_empty_elements=False)
+    
+    expected_final_prompt = sample_data["kb_template_content"].replace("{{documents}}", xml_without_paths)
     assert prompt_arg == expected_final_prompt
     
     # Check model argument passed to invoke

--- a/kb_for_prompt/tests/test_menu_system.py
+++ b/kb_for_prompt/tests/test_menu_system.py
@@ -494,7 +494,7 @@ class TestMenuSystemKbConfirmSave(unittest.TestCase):
         mock_prompt_save.return_value = True
         mock_save_method.return_value = True # Simulate successful save
         expected_preview = "\n".join(self.kb_content.splitlines()[:50]) + "\n[italic](... preview truncated ...)[/italic]"
-        expected_target_path = self.output_dir / "knowledge_base.xml"
+        expected_target_path = self.output_dir / "knowledge_base.md" # CHANGED EXTENSION
 
         self.menu._handle_kb_confirm_save()
 
@@ -515,7 +515,7 @@ class TestMenuSystemKbConfirmSave(unittest.TestCase):
         """Test handler when user confirms save but save fails."""
         mock_prompt_save.return_value = True
         mock_save_method.return_value = False # Simulate save failure
-        expected_target_path = self.output_dir / "knowledge_base.xml"
+        expected_target_path = self.output_dir / "knowledge_base.md" # CHANGED EXTENSION
 
         self.menu._handle_kb_confirm_save()
 


### PR DESCRIPTION
## Summary
This PR addresses issue #2 by changing the knowledge base output extension from `.xml` to `.md` and ensuring file paths are not included in the generated content.

## Changes
1. Changed the knowledge base file extension from `.xml` to `.md` in `menu_system.py`
2. Updated the KB extraction prompt to explicitly instruct not to include file paths
3. Modified `llm_generator.py` to strip path attributes from XML before sending to LLM
4. Updated related tests to reflect these changes

Fixes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Knowledge base generation now produces output in Markdown format instead of XML.
- **Bug Fixes**
	- Removed file path references from generated knowledge base content to ensure only relevant information is included.
- **Documentation**
	- Updated user instructions and prompts to clarify that file paths are excluded from the knowledge base and that output is now in Markdown format.
- **Tests**
	- Adjusted tests to expect Markdown output and verify that file paths are no longer present in generated knowledge base files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->